### PR TITLE
Strip spaces in the `comp_col` column during manifest validation

### DIFF
--- a/templates/validate_manifest.py
+++ b/templates/validate_manifest.py
@@ -204,6 +204,9 @@ def validate_manifest(manifest="input_manifest.csv"):
         msg = f"Found value ({comp_ref}) in column ({comp_col}) {ref_n} times"
         assert ref_n > 0, msg
 
+        # Make sure there are no extra spaces in the comp_col column
+        df[comp_col] = df[comp_col].str.strip()
+
         # Iterate over each of the unique values in the `comp_col` column
         for comp_val in df[comp_col].unique():
 


### PR DESCRIPTION
Fix issue if there are spaces in one of the comparison values.

sample error:

```
[validate_manifest] Formatting a table to compare  pre  vs. pre
```

Any other columns that we should trim?